### PR TITLE
Update Monaco font path for MacOS Monterey

### DIFF
--- a/Formula/hiptext.rb
+++ b/Formula/hiptext.rb
@@ -23,7 +23,7 @@ class Hiptext < Formula
     # Fix the font path
     # https://github.com/jart/hiptext/issues/12
     inreplace "src/font.cc", "DejaVuSansMono.ttf",
-                             "/System/Library/Fonts/Monaco.dfont"
+                             "/System/Library/Fonts/Monaco.ttf"
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
Three years later... still coming back for the `hiptext` formula... Much ❤️  

After updating to MacOS Monterey (Xcode 13.1) and running a fresh `brew tap crossroadsman/utils` and `brew reinstall hiptext` , I receive the following error on invocation:

```
F20211117 10:58:28.270709 258135552 font.cc:32] Check failed: 0 == FT_New_Face( g_library, FLAGS_font.c_str(), FLAGS_font_index, &g_face) (0 vs. 1)
*** Check failure stack trace: ***
    @        0x10294a882  google::LogMessage::SendToLog()
    @        0x10294aecf  google::LogMessage::Flush()
    @        0x10294e291  google::LogMessageFatal::~LogMessageFatal()
    @        0x10294b95b  google::LogMessageFatal::~LogMessageFatal()
    @        0x1026dd3a2  InitFont()
    @        0x1026db0a8  main
    @        0x10f5ba4fe  (unknown)
fish: Job 1, 'hiptext' terminated by signal SIGABRT (Abort)
```

Closest I can find on the internet is this reference which purports to fix the issue: https://github.com/jart/hiptext/issues/12#issuecomment-15411407 which implies a missing font path. 

While the attached PR works for Monterey, it's conceivable that there's some magic homebrew bottling that would include different instructions per OS version... which I lack time to research. 